### PR TITLE
Fix call to `mbstring` function

### DIFF
--- a/src/classes/Activation.php
+++ b/src/classes/Activation.php
@@ -5,6 +5,6 @@ namespace JB\MPS;
 class Activation {
 
   public static function init() {
-    /* Nothing to do... */ 
+    /* Nothing to do... */
   }
 }

--- a/src/classes/MetaBox.php
+++ b/src/classes/MetaBox.php
@@ -79,7 +79,7 @@ class MetaBox {
         "trying to upload is a PDF document, and has a <code>.pdf</code> " .
         "extension.";
       ?>
-        <div class="error">
+        <div class="notice notice-error is-dismissible">
           <p><?php echo $message; ?></p>
         </div>
       <?php

--- a/src/classes/ParserManager.php
+++ b/src/classes/ParserManager.php
@@ -2,9 +2,6 @@
 
 namespace JB\MPS;
 
-use \Smalot\PdfParser\Parser;
-use \Smalot\PdfParser\Font;
-
 class ParserManager {
 
   private $pdf_path;


### PR DESCRIPTION
The PdfParser library was calling `mb_check_encoding` to determine if a
string was valid UTF8. Since we don't have the `mbstring` module
compiled for our version of PHP, this commit uses a workaround (regex)
to accomplish the same thing, without depending on the `mbstring`
package.